### PR TITLE
Laget logikk for sletting av en rute og la til favorittrute_id på slu…

### DIFF
--- a/src/main/java/no/lambda/Storage/adapter/ReiseKlarAdapter.java
+++ b/src/main/java/no/lambda/Storage/adapter/ReiseKlarAdapter.java
@@ -127,11 +127,25 @@ public class ReiseKlarAdapter implements ReiseKlarPort {
                 coordinates.add(resultSet.getDouble(5));
                 //toLatitude
                 coordinates.add(resultSet.getDouble(6));
+                //favorittrute_id
+                coordinates.add(resultSet.getDouble(1));
                 amountOfFavorites.add(coordinates);
             }
             return amountOfFavorites;
         } catch (SQLException e) {
             throw new EnTurException("Could not get favorite routes based on Id", e);
+        }
+    }
+
+    @Override
+    public void deleteUserBasedOnFavoriteRouteId(int favorittruteId) throws MySQLDatabaseException {
+        //Sletter en rad fra Favorittrute-tabellen basert på favorittruteId
+        String sql = sqlStringAdapter.deleteUserBasedOnFavoriteRouteIdSQLQuery(favorittruteId);
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.executeUpdate();
+        } catch (SQLException e) {
+            throw new EnTurException("Could not delete favorite route", e);
         }
     }
 }

--- a/src/main/java/no/lambda/Storage/adapter/SQLStringAdapter.java
+++ b/src/main/java/no/lambda/Storage/adapter/SQLStringAdapter.java
@@ -38,6 +38,11 @@ public class SQLStringAdapter implements SQLStringPort {
                 "FROM Favorittrute\n" +
                 "WHERE bruker_id = "+brukerId;
     }
+
+    @Override
+    public String deleteUserBasedOnFavoriteRouteIdSQLQuery(int favorittruteId) throws MySQLDatabaseException {
+        return "DELETE FROM Favorittrute WHERE favorittrute_id = "+favorittruteId;
+    }
 }
 
 

--- a/src/main/java/no/lambda/port/ReiseKlarPort.java
+++ b/src/main/java/no/lambda/port/ReiseKlarPort.java
@@ -13,6 +13,7 @@ public interface ReiseKlarPort {
     Rute getFavoriteRoute(int favorittruteId) throws MySQLDatabaseException;
     ArrayList<Double> getToAndFromBasedOnFavoriteRouteIDAndUserID(int favorittruteId, int brukerId) throws MySQLDatabaseException;
     ArrayList<ArrayList<Double>> getFavoriteRoutesFromUserBasedOnId(int brukerId) throws MySQLDatabaseException;
+    void deleteUserBasedOnFavoriteRouteId(int favorittruteId) throws MySQLDatabaseException;
 }
 
 

--- a/src/main/java/no/lambda/port/SQLStringPort.java
+++ b/src/main/java/no/lambda/port/SQLStringPort.java
@@ -8,4 +8,5 @@ public interface SQLStringPort {
     String createUserSQLQuery(String fornavn, String etternavn) throws MySQLDatabaseException;
     String getToAndFromBasedOnFavoriteRouteIDAndUserIDSQLQuery(int favorittruteId, int brukerId) throws MySQLDatabaseException;
     String getFavoriteRoutesFromUserBasedOnIdSQLQuery(int brukerId) throws MySQLDatabaseException;
+    String deleteUserBasedOnFavoriteRouteIdSQLQuery(int favorittruteId) throws MySQLDatabaseException;
 }

--- a/src/test/java/integrationtest/ReiseKlarMySQLAdapterIntegrationTest.java
+++ b/src/test/java/integrationtest/ReiseKlarMySQLAdapterIntegrationTest.java
@@ -5,6 +5,8 @@ import no.lambda.model.Rute;
 import database.H2TestDatabase;
 import org.junit.jupiter.api.*;
 import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 //Ulike tester for metoder man kan bruke mot testdatabasen.
 public class ReiseKlarMySQLAdapterIntegrationTest {
@@ -62,6 +64,14 @@ public class ReiseKlarMySQLAdapterIntegrationTest {
     public void hentFavorittrute_favorittruteErHentetRiktig() throws Exception {
         //Arrange
         int favorittRuteId = 1;
+        ArrayList<ArrayList<Double>> favoritesList = new ArrayList<>();
+        ArrayList<Double> favoriteItem = new ArrayList<>();
+        favoriteItem.add(20.4);
+        favoriteItem.add(10.5);
+        favoriteItem.add(49.3);
+        favoriteItem.add(31.9);
+        favoriteItem.add(1.0);
+        favoritesList.add(favoriteItem);
 
         //Act
         Rute hentetFavorittrute = reiseKlar.getFavoriteRoute(favorittRuteId);
@@ -75,6 +85,27 @@ public class ReiseKlarMySQLAdapterIntegrationTest {
         Assertions.assertEquals(49.3, hentetFavorittrute.getTo_longitude());
         Assertions.assertEquals(31.9, hentetFavorittrute.getTo_latitude());
         Assertions.assertEquals(3, hentetFavorittrute.getTo_place_id());
+        //
+        Assertions.assertEquals(favoritesList, reiseKlar.getFavoriteRoutesFromUserBasedOnId(1));
+    }
+
+    //Tester om en favorittrute blir slettet på korrekt vis.
+    @Test
+    public void slettFavorittrute_favorittruteErSlettetRiktig() throws Exception {
+        //Arrange
+        Rute rute1 = new Rute(3, 1, 10, 15, 4, 20, 1);
+        Rute rute2 = new Rute(4, 2, 12, 13, 8, 19, 1);
+        Rute rute3 = new Rute(5, 2, 16, 11, 5, 18, 1);
+
+        //Act
+        reiseKlar.createFavoriteRoute(rute1);
+        reiseKlar.createFavoriteRoute(rute2);
+        reiseKlar.createFavoriteRoute(rute3);
+        reiseKlar.deleteUserBasedOnFavoriteRouteId(4);
+
+        //Assert
+        //Tester om antall rader i databasen er det som forventet etter at en rad er slettet fra den.
+        Assertions.assertEquals(3, testDB.countRowsInTable(("Favorittrute")));
     }
 }
 

--- a/src/test/java/unittest/ReiseKlarUnitTests.java
+++ b/src/test/java/unittest/ReiseKlarUnitTests.java
@@ -27,6 +27,7 @@ public class ReiseKlarUnitTests {
         String stringText2 = sqlStringAdapter.createFavoriteRouteSQLQuery(1, 10, 20, 30, 40, 1);
         String stringText3 = sqlStringAdapter.getToAndFromBasedOnFavoriteRouteIDAndUserIDSQLQuery(1, 1);
         String stringText4 = sqlStringAdapter.getFavoriteRoutesFromUserBasedOnIdSQLQuery(1);
+        String stringText5 = sqlStringAdapter.deleteUserBasedOnFavoriteRouteIdSQLQuery(1);
 
         //Assert
         Assertions.assertEquals(("INSERT INTO Bruker(fornavn, etternavn)\n" + "VALUES ('Jane', 'Doe')"), stringText1);
@@ -38,6 +39,7 @@ public class ReiseKlarUnitTests {
         Assertions.assertEquals(("SELECT *\n" +
                 "FROM Favorittrute\n" +
                 "WHERE bruker_id = "+1), stringText4);
+        Assertions.assertEquals("DELETE FROM Favorittrute WHERE favorittrute_id = " + 1, stringText5);
     }
 }
 


### PR DESCRIPTION
This pull request introduces the ability to delete a user's favorite route by its ID, along with corresponding updates to the data access layer, interface definitions, and comprehensive tests to ensure correctness. The changes enhance the application's CRUD capabilities for favorite routes.

### Feature: Delete favorite route by ID

* Added `deleteUserBasedOnFavoriteRouteId(int favorittruteId)` method to `ReiseKlarAdapter`, which deletes a row from the `Favorittrute` table based on the favorite route ID.
* Implemented `deleteUserBasedOnFavoriteRouteIdSQLQuery(int favorittruteId)` in `SQLStringAdapter` to generate the appropriate SQL delete statement.

### Interface updates

* Extended `ReiseKlarPort` and `SQLStringPort` interfaces to include the new delete method and SQL query method, respectively. [[1]](diffhunk://#diff-a4c7dd492c9b21414574b9cd4ebfcb461e125dc60093f48dabcdb8e48d2e556cR16) [[2]](diffhunk://#diff-6697271bfa1b899ea4e4fb353bb21edfa8d6aaf2fe624691ed21994cfae36e60R11)

### Testing

* Added integration test `slettFavorittrute_favorittruteErSlettetRiktig` in `ReiseKlarMySQLAdapterIntegrationTest` to verify correct deletion of a favorite route and database row count.
* Updated unit test `SQLStringAdapter_StringsCreatedSuccessfully` to check that the SQL string for deleting a favorite route is generated as expected. [[1]](diffhunk://#diff-54f508ed4895761e3602992c12a59a62bd895264dad7fca529b348a8b01bd183R30) [[2]](diffhunk://#diff-54f508ed4895761e3602992c12a59a62bd895264dad7fca529b348a8b01bd183R42)…tten av å hente koordinater basert på favorittrute_id.