### PR TITLE
Bugfix geocode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,8 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+#!workflow is currently not in-use!
+
 trigger:
 - develop
 

--- a/src/main/java/no/lambda/client/entur/Geocoder/EnturGeocoderClient.java
+++ b/src/main/java/no/lambda/client/entur/Geocoder/EnturGeocoderClient.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 // Klient for Entur sin Geocoding/Autocomplete-API
 public class EnturGeocoderClient {
     // Record for geo data for POI/addresse/Stop. En uforanderlig data-holder.
-    public record GeoHit(String label,String County ,double latitude, double longitude, String placeId){ }
+    public record GeoHit(String label ,double latitude, double longitude, String placeId){ }
 
     private final OkHttpClient httpClient; // HTTP-klient for nettverksforespørsler
     private final ObjectMapper mapper; // Jackson for JSON-mapping
@@ -79,7 +79,6 @@ public class EnturGeocoderClient {
                 hits.add(
                         new GeoHit(
                                 properties.get("label").asText(), // Navn på stedet/adressen
-                                properties.get("county").asText(), // Fylke
                                 coordinates.get(1).asDouble(), // Latitude (Indeks 1)
                                 coordinates.get(0).asDouble(), // Longitude (Indeks 0)
                                 // Henter ID hvis den finnes, ellers null

--- a/src/main/java/no/lambda/presentation/javalin/AutocompleteAPI.java
+++ b/src/main/java/no/lambda/presentation/javalin/AutocompleteAPI.java
@@ -55,7 +55,6 @@ public class AutocompleteAPI {
             for (var suggested : suggestions) {
                 ArrayList<String> pair = new ArrayList<>();
                 pair.add(suggested.label());
-                pair.add(suggested.County());
                 response.add(pair);
             }
 

--- a/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
+++ b/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
@@ -83,14 +83,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
             var h0 = hits.get(0);
             assertEquals("Halden", h0.label());
-            assertEquals("Østfold", h0.County());
             assertEquals(59.119946, h0.latitude(), 1e-6);
             assertEquals(11.384822, h0.longitude(), 1e-6);
             assertEquals("NSR:GroupOfStopPlaces:33", h0.placeId());
 
             var h1 = hits.get(1);
             assertEquals("Halden, Bærum", h1.label());
-            assertEquals("Akershus", h1.County());
+
             assertEquals(59.885534, h1.latitude(), 1e-6);
             assertEquals(10.62056, h1.longitude(), 1e-6);
             assertEquals("NSR:StopPlace:3634", h1.placeId());


### PR DESCRIPTION
This pull request removes the `County` field from the `GeoHit` record and updates all related code to reflect this change. This simplifies the geocoding data model and eliminates the need to handle county information throughout the codebase.

Geocoding data model simplification:

* Removed the `County` field from the `GeoHit` record in `EnturGeocoderClient.java`, reducing the number of fields and simplifying the data structure.
* Updated the `geoCode` method in `EnturGeocoderClient.java` to no longer extract or store county information from API responses.

API and test adjustments:

* Modified the `AutocompleteAPI.java` to remove county information from API responses.
* Updated tests in `EnturGeocodeTest.java` to remove assertions related to the county field.

Documentation:

* Added a comment in `azure-pipelines.yml` indicating that the workflow is currently not in use.