### PR TITLE
comments i Geocode og GraphQLClient testene

### DIFF
--- a/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
+++ b/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
@@ -130,6 +130,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
         @Test
+        //tester at EnturGeocoderException kastes ved feil
         void geoCode_httpError_throwsDomainException() {
             server.enqueue(new MockResponse().setResponseCode(503).setBody("Service Unavailable"));
             EnturGeocoderClient client = newClient();

--- a/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
+++ b/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
@@ -39,6 +39,7 @@ public class EnturGraphQLTest {
     }
 
     @Test
+    //tester om responsen fra EnturGraphQLClient blir korrekt mappet
     void execute_parsesRealEnturGraphQLPayload() throws InterruptedException {
 
         String body = """
@@ -116,6 +117,7 @@ public class EnturGraphQLTest {
     }
 
     @Test
+    //tester at en tom query kaster EnturGraphQLExceptions
     void execute_httpError_throwsCustomException() {
         server.enqueue(new MockResponse().setResponseCode(502).setBody("Bad Gateway"));
 


### PR DESCRIPTION
This pull request adds clarifying comments to unit tests in the geocoding and GraphQL client test suites. The comments describe the purpose of each test, making it easier to understand what is being tested and what exceptions are expected.

Test documentation improvements:

* Added a comment to `geoCode_httpError_throwsDomainException` in `EnturGeocodeTest.java` to clarify that it tests for an `EnturGeocoderException` when an HTTP error occurs.
* Added a comment to `execute_parsesRealEnturGraphQLPayload` in `EnturGraphQLTest.java` to explain that it checks if the response from `EnturGraphQLClient` is mapped correctly.
* Added a comment to `execute_httpError_throwsCustomException` in `EnturGraphQLTest.java` to clarify that it verifies an exception is thrown for an empty query.