### PR TITLE
fikset kommentar

### DIFF
--- a/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
+++ b/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
@@ -117,7 +117,7 @@ public class EnturGraphQLTest {
     }
 
     @Test
-    //tester at en tom query kaster EnturGraphQLExceptions
+        //tester at HTTP-feil kaster EnturGraphQLExceptions
     void execute_httpError_throwsCustomException() {
         server.enqueue(new MockResponse().setResponseCode(502).setBody("Bad Gateway"));
 


### PR DESCRIPTION
This pull request updates a test in `EnturGraphQLTest.java` to clarify its purpose. The comment above the `execute_httpError_throwsCustomException` test now specifies that it checks for HTTP errors throwing `EnturGraphQLExceptions`, rather than for empty queries.

* Test documentation update:
  * The test comment in `EnturGraphQLTest.java` was changed to clarify that it verifies HTTP errors result in `EnturGraphQLExceptions`.