### PR TITLE
Bug fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-#!workflow is currently not in-use!
+# Workflow is currently not in use!
 
 trigger:
 - develop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,8 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+#!workflow is currently not in-use!
+
 trigger:
 - develop
 

--- a/src/main/java/no/lambda/client/entur/Geocoder/EnturGeocoderClient.java
+++ b/src/main/java/no/lambda/client/entur/Geocoder/EnturGeocoderClient.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 // Klient for Entur sin Geocoding/Autocomplete-API
 public class EnturGeocoderClient {
     // Record for geo data for POI/addresse/Stop. En uforanderlig data-holder.
-    public record GeoHit(String label ,double latitude, double longitude, String placeId){ }
+    public record GeoHit(String label, double latitude, double longitude, String placeId){ }
 
     private final OkHttpClient httpClient; // HTTP-klient for nettverksforespørsler
     private final ObjectMapper mapper; // Jackson for JSON-mapping

--- a/src/main/java/no/lambda/client/entur/Geocoder/EnturGeocoderClient.java
+++ b/src/main/java/no/lambda/client/entur/Geocoder/EnturGeocoderClient.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 // Klient for Entur sin Geocoding/Autocomplete-API
 public class EnturGeocoderClient {
     // Record for geo data for POI/addresse/Stop. En uforanderlig data-holder.
-    public record GeoHit(String label,String County ,double latitude, double longitude, String placeId){ }
+    public record GeoHit(String label ,double latitude, double longitude, String placeId){ }
 
     private final OkHttpClient httpClient; // HTTP-klient for nettverksforespørsler
     private final ObjectMapper mapper; // Jackson for JSON-mapping
@@ -79,7 +79,6 @@ public class EnturGeocoderClient {
                 hits.add(
                         new GeoHit(
                                 properties.get("label").asText(), // Navn på stedet/adressen
-                                properties.get("county").asText(), // Fylke
                                 coordinates.get(1).asDouble(), // Latitude (Indeks 1)
                                 coordinates.get(0).asDouble(), // Longitude (Indeks 0)
                                 // Henter ID hvis den finnes, ellers null

--- a/src/main/java/no/lambda/presentation/javalin/AutocompleteAPI.java
+++ b/src/main/java/no/lambda/presentation/javalin/AutocompleteAPI.java
@@ -55,7 +55,6 @@ public class AutocompleteAPI {
             for (var suggested : suggestions) {
                 ArrayList<String> pair = new ArrayList<>();
                 pair.add(suggested.label());
-                pair.add(suggested.County());
                 response.add(pair);
             }
 

--- a/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
+++ b/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
@@ -83,14 +83,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
             var h0 = hits.get(0);
             assertEquals("Halden", h0.label());
-            assertEquals("Østfold", h0.County());
             assertEquals(59.119946, h0.latitude(), 1e-6);
             assertEquals(11.384822, h0.longitude(), 1e-6);
             assertEquals("NSR:GroupOfStopPlaces:33", h0.placeId());
 
             var h1 = hits.get(1);
             assertEquals("Halden, Bærum", h1.label());
-            assertEquals("Akershus", h1.County());
+
             assertEquals(59.885534, h1.latitude(), 1e-6);
             assertEquals(10.62056, h1.longitude(), 1e-6);
             assertEquals("NSR:StopPlace:3634", h1.placeId());

--- a/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
+++ b/src/test/java/enturGeocodeTest/EnturGeocodeTest.java
@@ -130,6 +130,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
         @Test
+        //tester at EnturGeocoderException kastes ved feil
         void geoCode_httpError_throwsDomainException() {
             server.enqueue(new MockResponse().setResponseCode(503).setBody("Service Unavailable"));
             EnturGeocoderClient client = newClient();

--- a/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
+++ b/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
@@ -39,6 +39,7 @@ public class EnturGraphQLTest {
     }
 
     @Test
+    //tester om responsen fra EnturGraphQLClient blir korrekt mappet
     void execute_parsesRealEnturGraphQLPayload() throws InterruptedException {
 
         String body = """
@@ -116,6 +117,7 @@ public class EnturGraphQLTest {
     }
 
     @Test
+    //tester at en tom query kaster EnturGraphQLExceptions
     void execute_httpError_throwsCustomException() {
         server.enqueue(new MockResponse().setResponseCode(502).setBody("Bad Gateway"));
 

--- a/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
+++ b/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
@@ -39,7 +39,7 @@ public class EnturGraphQLTest {
     }
 
     @Test
-    //tester om responsen fra EnturGraphQLClient blir korrekt mappet
+    // Tester om responsen fra EnturGraphQLClient blir korrekt mappet.
     void execute_parsesRealEnturGraphQLPayload() throws InterruptedException {
 
         String body = """

--- a/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
+++ b/src/test/java/enturGraphQLTest/EnturGraphQLTest.java
@@ -117,7 +117,7 @@ public class EnturGraphQLTest {
     }
 
     @Test
-    //tester at en tom query kaster EnturGraphQLExceptions
+        //tester at HTTP-feil kaster EnturGraphQLExceptions
     void execute_httpError_throwsCustomException() {
         server.enqueue(new MockResponse().setResponseCode(502).setBody("Bad Gateway"));
 


### PR DESCRIPTION
This pull request primarily removes the `County` field from the `GeoHit` record and updates all related usages throughout the codebase and tests to reflect this change. Additionally, minor comments were added to clarify the purpose of certain test methods.

### Removal of `County` field from geocoding results

* The `County` field was removed from the `GeoHit` record in `EnturGeocoderClient.java`, simplifying the model for geocoding results.
* All code that referenced or accessed the `County` field, including construction of `GeoHit` objects and API responses in `AutocompleteAPI.java`, was updated to remove this dependency. [[1]](diffhunk://#diff-3e91c09bde1acd618869220101af3914eb51eccda2041f1335b1f0d855d8ca18L82) [[2]](diffhunk://#diff-dca6828398e38f6ca8d8a203f9611ff87db1e88c5f9ba61f45995e1cbb5282adL58)

### Updates to tests

* All assertions and test payloads expecting the `County` field in `GeoHit` were updated or removed in `EnturGeocodeTest.java` to match the new model.
* Added clarifying comments to test methods in both `EnturGeocodeTest.java` and `EnturGraphQLTest.java` to describe their purpose, improving test readability and maintainability. [[1]](diffhunk://#diff-00d13f87e17898cc11f14110280498fdec38a21ae3f899dfae9c0e2a50ff37eeR133) [[2]](diffhunk://#diff-c51971d0fa446ad39e311cd344ae95b2f0ead4931f3fee11f1f111473aa6348bR42) [[3]](diffhunk://#diff-c51971d0fa446ad39e311cd344ae95b2f0ead4931f3fee11f1f111473aa6348bR120)

### Miscellaneous

* Added a comment to `azure-pipelines.yml` indicating that the workflow is currently not in use.